### PR TITLE
Prevent ResizeObserver loop limit error

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -24,7 +24,7 @@
     {
       "files": "tests/**/*-test.js",
       "options": {
-        "printWidth": 100
+        "printWidth": 90
       }
     }
   ]

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ember-cli-babel": "^7.20.5",
     "ember-cli-htmlbars": "^5.1.2",
     "ember-modifier": "^1.0.3",
-    "ember-resize-observer-service": "^0.1.0"
+    "ember-resize-observer-service": "^0.2.0"
   },
   "devDependencies": {
     "@ember/optional-features": "^1.3.0",

--- a/tests/integration/modifiers/on-resize-test.js
+++ b/tests/integration/modifiers/on-resize-test.js
@@ -29,7 +29,9 @@ module('Integration | Modifier | on-resize', function (hooks) {
       .calledOnce('called onResize on insert')
       .calledWithExactly([sinon.match.instanceOf(ResizeObserverEntry)])
       .calledWithExactly([sinon.match({ target: element })])
-      .calledWithExactly([sinon.match({ contentRect: sinon.match({ height: 100, width: 100 }) })]);
+      .calledWithExactly([
+        sinon.match({ contentRect: sinon.match({ height: 100, width: 100 }) }),
+      ]);
 
     this.onResize.resetHistory();
     await setSize(element, { width: 50 });
@@ -38,7 +40,9 @@ module('Integration | Modifier | on-resize', function (hooks) {
       .spy(this.onResize)
       .calledOnce('called onResize on width change')
       .calledWithExactly([sinon.match({ target: element })])
-      .calledWithExactly([sinon.match({ contentRect: sinon.match({ height: 100, width: 50 }) })]);
+      .calledWithExactly([
+        sinon.match({ contentRect: sinon.match({ height: 100, width: 50 }) }),
+      ]);
 
     this.onResize.resetHistory();
     await setSize(element, { height: 50 });
@@ -47,7 +51,9 @@ module('Integration | Modifier | on-resize', function (hooks) {
       .spy(this.onResize)
       .calledOnce('called onResize on height change')
       .calledWithExactly([sinon.match({ target: element })])
-      .calledWithExactly([sinon.match({ contentRect: sinon.match({ height: 50, width: 50 }) })]);
+      .calledWithExactly([
+        sinon.match({ contentRect: sinon.match({ height: 50, width: 50 }) }),
+      ]);
 
     this.onResize.resetHistory();
     await setSize(element, { width: 50 });
@@ -80,7 +86,9 @@ module('Integration | Modifier | on-resize', function (hooks) {
       .spy(this.onResize)
       .calledOnce()
       .calledWithExactly([sinon.match({ target: element })])
-      .calledWithExactly([sinon.match({ contentRect: sinon.match({ height: 0, width: 0 }) })]);
+      .calledWithExactly([
+        sinon.match({ contentRect: sinon.match({ height: 0, width: 0 }) }),
+      ]);
   });
 
   test('using multiple modifiers for the same element', async function (assert) {
@@ -200,5 +208,18 @@ module('Integration | Modifier | on-resize', function (hooks) {
         </div>
       `);
     });
+  });
+
+  test('prevents ResizeObserver loop limit related errors', async function (assert) {
+    assert.expect(0);
+    this.onResize = () => this.set('showText', true);
+
+    await render(hbs`
+      <div {{on-resize this.onResize}}>
+        {{if this.showText "Trigger ResizeObserver again"}}
+      </div>
+    `);
+
+    delay();
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -4829,10 +4829,10 @@ ember-qunit@^4.6.0:
     ember-cli-test-loader "^2.2.0"
     qunit "^2.9.3"
 
-ember-resize-observer-service@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/ember-resize-observer-service/-/ember-resize-observer-service-0.1.0.tgz#d38fd409ee2f285b865de2c2c620cfd1d42b6f34"
-  integrity sha512-9CNsh1+ExLYfdVlgIZS9MdWglfI180KWezlRRqemtH4KNVCP60BVAQV6F8clDjfBpnrZbGWKkZ0kZccxpft3kQ==
+ember-resize-observer-service@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/ember-resize-observer-service/-/ember-resize-observer-service-0.2.0.tgz#28bb61fa9a85a49851a5e67920a927100ff43e5d"
+  integrity sha512-LKmc5hv1UHDyX+U/bI3pk+NMjuJD/dLqL4R51G3LSlYTHTJn6Y0Cs0c9g3j6vK5BBDDJGi6mTGqFM/dRXKkRpQ==
   dependencies:
     ember-cli-babel "^7.20.5"
     ember-cli-htmlbars "^5.1.2"


### PR DESCRIPTION
It happens when you trigger `ResizeObserver` observation in the same animation frame again. The `ResizeObserver` loop protection will move the observation to the next frame and fire an error event `ResizeObserver loop limit exceeded`. The error can be safely ignored, though it can still fail tests and make noise in services like Sentry.

An example:

```js
// inside of a component class...

showText = false;

@action
handleResize() {
  this.showText = true;
}
```

```hbs
<div {{on-resize this.handleResize}}>
  {{if this.showText "Rendering this text will resize the div element which will trigger observation again"}}
</div>
```

Related to: https://github.com/PrecisionNutrition/ember-resize-observer-service/pull/1